### PR TITLE
1 fix slider

### DIFF
--- a/dest/main.js
+++ b/dest/main.js
@@ -182,7 +182,8 @@ $carousel.flickity({
   contain: true,
   wrapAround: true,
   prevNextButtons: false,
-  autoPlay: 2500,
+  autoPlay: 2000,
+  pauseAutoPlayOnHover: false,
   on: {
     ready: function () {
       let dotted = $(".flickity-page-dots");

--- a/dest/main.js
+++ b/dest/main.js
@@ -182,7 +182,7 @@ $carousel.flickity({
   contain: true,
   wrapAround: true,
   prevNextButtons: false,
-  autoPlay: 2000,
+  autoPlay: 2500,
   pauseAutoPlayOnHover: false,
   on: {
     ready: function () {


### PR DESCRIPTION
- fix slider 
- Auto-playing will pause when the user hovers over the carousel. Set pauseAutoPlayOnHover: false to disable this behavior.